### PR TITLE
Add owner-managed controls to BaseMgroOapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ public/injected-provider.bundle.js
 # for Yarn 3
 .yarn
 *.scss.d.ts
+# foundry
+/out
+/cache

--- a/contracts/BaseMgroOapp.sol
+++ b/contracts/BaseMgroOapp.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "./utils/Ownable.sol";
+
+/// @title BaseMgroOapp
+/// @notice Provides shared management configuration guarded by an ownership primitive.
+abstract contract BaseMgroOapp is Ownable {
+    address internal _management;
+
+    event ManagementUpdated(address indexed previousManagement, address indexed newManagement);
+
+    constructor(address management_, address owner_) Ownable(owner_) {
+        _setManagement(management_);
+    }
+
+    function management() public view returns (address) {
+        return _management;
+    }
+
+    function setManagement(address newManagement) public onlyOwner {
+        _setManagement(newManagement);
+    }
+
+    function _setManagement(address newManagement) internal {
+        require(newManagement != address(0), "BaseMgroOapp: zero address");
+        address previousManagement = _management;
+        _management = newManagement;
+        emit ManagementUpdated(previousManagement, newManagement);
+    }
+}

--- a/contracts/utils/Ownable.sol
+++ b/contracts/utils/Ownable.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice Minimal ownership primitive modeled after OpenZeppelin's Ownable contract.
+abstract contract Ownable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    constructor(address initialOwner) {
+        require(initialOwner != address(0), "Ownable: initial owner is the zero address");
+        _transferOwnership(initialOwner);
+    }
+
+    modifier onlyOwner() {
+        require(owner() == msg.sender, "Ownable: caller is not the owner");
+        _;
+    }
+
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    function renounceOwnership() public onlyOwner {
+        _transferOwnership(address(0));
+    }
+
+    function transferOwnership(address newOwner) public onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _transferOwnership(newOwner);
+    }
+
+    function _transferOwnership(address newOwner) internal {
+        address previousOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(previousOwner, newOwner);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "contracts"
+test = "test"
+libs = ["lib"]
+out = "out"
+cache_path = "cache"
+solc_version = "0.8.20"

--- a/test/BaseMgroOapp.t.sol
+++ b/test/BaseMgroOapp.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {BaseMgroOapp} from "../contracts/BaseMgroOapp.sol";
+
+contract BaseMgroOappHarness is BaseMgroOapp {
+    constructor(address management_, address owner_) BaseMgroOapp(management_, owner_) {}
+}
+
+contract UnauthorizedCaller {
+    function attemptSetManagement(BaseMgroOapp target, address newManagement) external {
+        target.setManagement(newManagement);
+    }
+}
+
+contract BaseMgroOappTest {
+    BaseMgroOappHarness internal base;
+    UnauthorizedCaller internal attacker;
+
+    function setUp() public {
+        base = new BaseMgroOappHarness(address(0xABCD), address(this));
+        attacker = new UnauthorizedCaller();
+    }
+
+    function testOwnerCanUpdateManagement() public {
+        address newManagement = address(0x1234);
+        base.setManagement(newManagement);
+        assertEq(base.management(), newManagement, "management should update for owner");
+    }
+
+    function testUnauthorizedCallerReverts() public {
+        try attacker.attemptSetManagement(base, address(0x5678)) {
+            fail("unauthorized caller should revert");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Ownable: caller is not the owner", "unexpected revert reason");
+        }
+    }
+
+    function fail(string memory message) internal pure {
+        revert(message);
+    }
+
+    function assertEq(address a, address b, string memory message) internal pure {
+        if (a != b) {
+            revert(message);
+        }
+    }
+
+    function assertEq(string memory a, string memory b, string memory message) internal pure {
+        if (keccak256(bytes(a)) != keccak256(bytes(b))) {
+            revert(message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a minimal Ownable primitive so BaseMgroOapp can be owner-gated
- guard setManagement with onlyOwner and emit management update events
- add Foundry configuration and Solidity tests that cover authorized and unauthorized callers

## Testing
- not run (forge unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2740a3000832897df54b23e2a0a75