### PR TITLE
Add agent workflow playground

### DIFF
--- a/src/libs/agent-workflow/agent.ts
+++ b/src/libs/agent-workflow/agent.ts
@@ -1,0 +1,70 @@
+import { ConversationMemory } from './memory';
+import { HeuristicLLM } from './llm';
+import {
+  AgentLike,
+  AgentRunContext,
+  AgentStepResult,
+  ToolExecutionDetail,
+  ToolInvocationPlan
+} from './types';
+
+export interface AgentOptions {
+  name: string;
+  description?: string;
+  llm?: HeuristicLLM;
+  tools?: ToolInvocationPlan['tool'][];
+  systemPrompt?: string;
+  memorySize?: number;
+}
+
+export class Agent implements AgentLike {
+  public readonly name: string;
+  public readonly description?: string;
+  private readonly llm: HeuristicLLM;
+  private readonly tools: ToolInvocationPlan['tool'][];
+  private readonly systemPrompt: string;
+  private readonly memory: ConversationMemory;
+
+  constructor(options: AgentOptions) {
+    this.name = options.name;
+    this.description = options.description;
+    this.llm = options.llm ?? new HeuristicLLM();
+    this.tools = options.tools ?? [];
+    this.systemPrompt = options.systemPrompt ?? `${this.name} is a diligent specialist.`;
+    this.memory = new ConversationMemory(options.memorySize);
+  }
+
+  get availableTools() {
+    return this.tools;
+  }
+
+  async runStep(context: AgentRunContext): Promise<AgentStepResult> {
+    const toolDetails: ToolExecutionDetail[] = context.toolResults;
+
+    const prompt = [this.systemPrompt, context.prompt]
+      .concat(
+        toolDetails.length
+          ? [`Tool Findings:\n${toolDetails.map((detail) => `- ${detail.label}: ${detail.output}`).join('\n')}`]
+          : []
+      )
+      .join('\n\n');
+
+    const history = this.memory.snapshot();
+
+    this.memory.append({ role: 'user', content: context.prompt, timestamp: Date.now() });
+
+    const response = await this.llm.generate({ prompt, context: history });
+
+    this.memory.append({ role: 'assistant', content: response.content, timestamp: Date.now() });
+
+    return {
+      response,
+      prompt,
+      toolResults: toolDetails
+    };
+  }
+
+  reset() {
+    this.memory.clear();
+  }
+}

--- a/src/libs/agent-workflow/examples.ts
+++ b/src/libs/agent-workflow/examples.ts
@@ -1,0 +1,174 @@
+import { Agent } from './agent';
+import { HeuristicLLM } from './llm';
+import { StaticSearchDataset, StaticSearchTool, VirtualFileTool } from './tools';
+import { WorkflowEngine } from './workflow';
+import { WorkflowState } from './types';
+
+export interface Workspace {
+  workflow: WorkflowEngine;
+  searchTool: StaticSearchTool;
+  fileTool: VirtualFileTool;
+  agents: Agent[];
+}
+
+const DATASET: StaticSearchDataset[] = [
+  {
+    topic: 'elon musk',
+    headline: 'Starlink expands coverage to new maritime corridors',
+    details:
+      'SpaceX announces that Starlink Maritime now offers high-bandwidth coverage for transatlantic cargo ships with 35% lower latency.',
+    timestamp: '2025-02-11',
+    url: 'https://news.example.com/spacex-starlink-maritime-expansion'
+  },
+  {
+    topic: 'elon musk',
+    headline: 'Tesla introduces adaptive energy routing for Superchargers',
+    details:
+      'The firmware update allows Superchargers to rebalance demand across a city, reducing queue times in peak hours by up to 22%.',
+    timestamp: '2025-02-09'
+  },
+  {
+    topic: 'spacex',
+    headline: 'Starship completes reusable heat shield stress test',
+    details:
+      'The latest prototype survived a rapid reentry simulation, clearing the way for the first crewed lunar rehearsal mission.',
+    timestamp: '2025-02-02'
+  },
+  {
+    topic: 'tesla',
+    headline: 'Tesla Energy partners with European grid operator on AI balancing',
+    details:
+      'A new partnership with ENTSO-E will allow Tesla Megapacks to respond automatically to grid imbalances across five countries.',
+    timestamp: '2025-01-28'
+  },
+  {
+    topic: 'neuralink',
+    headline: 'Neuralink receives expanded FDA approval for precision motor trials',
+    details:
+      'The approval expands its trial cohort to include spinal cord injury patients focusing on restoring fine motor control.',
+    timestamp: '2025-01-24'
+  }
+];
+
+export function createNewsResearchWorkspace(): Workspace {
+  const searchTool = new StaticSearchTool({ dataset: DATASET });
+  const fileTool = new VirtualFileTool();
+
+  const researchLLM = new HeuristicLLM({ id: 'research-llm', name: 'Analytical Researcher', style: 'analysis' });
+  const plannerLLM = new HeuristicLLM({ id: 'planner-llm', name: 'Structured Planner', style: 'planner' });
+  const archivistLLM = new HeuristicLLM({ id: 'archivist-llm', name: 'Story Weaver', style: 'creative' });
+
+  const researchAgent = new Agent({
+    name: 'Research Analyst',
+    description: 'Collects the most relevant curated insights for a topic using available tools.',
+    llm: researchLLM,
+    tools: [searchTool],
+    systemPrompt:
+      'You are a research analyst synthesizing high-signal technology updates. Highlight clear facts and context. '
+  });
+
+  const strategistAgent = new Agent({
+    name: 'Strategy Planner',
+    description: 'Transforms raw findings into structured plans focused on clarity and priority.',
+    llm: plannerLLM,
+    systemPrompt:
+      'You produce actionable plans with numbered steps. Keep instructions concise and highlight measurable outcomes.'
+  });
+
+  const archivistAgent = new Agent({
+    name: 'Archivist',
+    description: 'Archives insights into well-formatted markdown files for later review.',
+    llm: archivistLLM,
+    tools: [fileTool],
+    systemPrompt: 'You craft narrative summaries that read naturally while preserving key facts.'
+  });
+
+  const workflow = new WorkflowEngine({
+    id: 'news-research',
+    title: 'News Research Workflow',
+    description: 'Collects curated updates, synthesizes them into a plan, and archives the deliverable.',
+    steps: [
+      {
+        id: 'research',
+        title: 'Collect curated updates',
+        description: 'Gather relevant curated snippets about the requested topic.',
+        agent: researchAgent,
+        prepare: ({ input }) => {
+          const topic = String(input.topic ?? '').trim();
+          const instructions = String(input.instructions ?? '').trim();
+          return {
+            prompt: `Topic: ${topic || 'unknown topic'}\n${
+              instructions ? `Primary instruction: ${instructions}\n` : ''
+            }Explain why the updates below matter for our stakeholders.`,
+            toolInvocations: [
+              {
+                tool: searchTool,
+                label: 'Curated search results',
+                input: {
+                  query: topic || 'technology'
+                }
+              }
+            ],
+            metadata: { topic }
+          };
+        }
+      },
+      {
+        id: 'synthesize',
+        title: 'Transform research into plan',
+        description: 'Use the curated snippets to build an actionable plan.',
+        agent: strategistAgent,
+        dependsOn: ['research'],
+        prepare: ({ input, state }) => {
+          const topic = String(input.topic ?? '').trim();
+          const instructions = String(input.instructions ?? '').trim();
+          const research = state.research?.output.response.content ?? 'No findings available.';
+          return {
+            prompt: `We are planning next steps for ${topic || 'the topic'}. ${
+              instructions ? `Follow the guidance: ${instructions}. ` : ''
+            }Use the findings below to build a numbered strategy.\n\nFindings:\n${research}`,
+            metadata: { topic }
+          };
+        }
+      },
+      {
+        id: 'archive',
+        title: 'Archive deliverable',
+        description: 'Store the synthesized plan in a markdown file.',
+        agent: archivistAgent,
+        dependsOn: ['synthesize'],
+        prepare: ({ input, state }) => {
+          const fileName = String(input.fileName ?? '').trim() || 'insights.md';
+          const summary = state.synthesize?.output.response.content ?? 'No summary created.';
+          const topic = String(input.topic ?? '').trim() || 'General Update';
+
+          return {
+            prompt: `Compose a short introduction for the archived note on ${topic}.`,
+            toolInvocations: [
+              {
+                tool: fileTool,
+                label: 'Save summary',
+                input: {
+                  path: fileName,
+                  content: `# ${topic} Update\n\n${summary}`
+                }
+              }
+            ],
+            metadata: { fileName, topic }
+          };
+        }
+      }
+    ]
+  });
+
+  return {
+    workflow,
+    searchTool,
+    fileTool,
+    agents: [researchAgent, strategistAgent, archivistAgent]
+  };
+}
+
+export function extractStepMarkdown(state: WorkflowState, id: string): string | undefined {
+  return state[id]?.output.response.content;
+}

--- a/src/libs/agent-workflow/index.ts
+++ b/src/libs/agent-workflow/index.ts
@@ -1,0 +1,6 @@
+export * from './agent';
+export * from './llm';
+export * from './tools';
+export * from './types';
+export * from './workflow';
+export * from './memory';

--- a/src/libs/agent-workflow/llm.ts
+++ b/src/libs/agent-workflow/llm.ts
@@ -1,0 +1,108 @@
+import { LLM, LLMRequest, LLMResponse } from './types';
+
+export interface HeuristicLLMOptions {
+  id?: string;
+  name?: string;
+  style?: 'analysis' | 'planner' | 'creative';
+  maxTokens?: number;
+}
+
+const SUMMARY_SENTENCE_LIMIT = 4;
+
+export class HeuristicLLM implements LLM {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly supportsStreaming = false;
+  private readonly style: HeuristicLLMOptions['style'];
+  private readonly maxTokens: number;
+
+  constructor(options: HeuristicLLMOptions = {}) {
+    this.id = options.id ?? 'heuristic-llm';
+    this.name = options.name ?? 'Heuristic LLM';
+    this.style = options.style ?? 'analysis';
+    this.maxTokens = options.maxTokens ?? 400;
+  }
+
+  async generate(request: LLMRequest): Promise<LLMResponse> {
+    const context = [...(request.context ?? []), request.prompt]
+      .join('\n')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    const tokens = context.split(/\s+/).filter(Boolean);
+    const clippedTokens = tokens.slice(-this.maxTokens);
+
+    let content = this.generateByStyle(clippedTokens.join(' '));
+
+    return {
+      content,
+      tokensUsed: clippedTokens.length,
+      metadata: {
+        style: this.style,
+        originalTokens: tokens.length
+      }
+    };
+  }
+
+  private generateByStyle(text: string): string {
+    if (!text) {
+      return 'No relevant information was provided.';
+    }
+
+    const sentences = text
+      .split(/(?<=[.!?])\s+/)
+      .map((sentence) => sentence.trim())
+      .filter(Boolean);
+
+    const selected = sentences.slice(-SUMMARY_SENTENCE_LIMIT);
+    const baseSummary = selected.join(' ');
+
+    switch (this.style) {
+      case 'planner':
+        return this.createPlannerSummary(baseSummary);
+      case 'creative':
+        return this.createCreativeSummary(baseSummary);
+      case 'analysis':
+      default:
+        return this.createAnalyticalSummary(baseSummary);
+    }
+  }
+
+  private createAnalyticalSummary(summary: string): string {
+    const bulletPoints = summary.split(/,|;|\band\b/i).map((point) => point.trim()).filter(Boolean);
+    if (bulletPoints.length <= 1) {
+      return `Key Insight: ${summary}`;
+    }
+
+    const rendered = bulletPoints
+      .slice(0, 5)
+      .map((point) => `- ${point.charAt(0).toUpperCase()}${point.slice(1)}`)
+      .join('\n');
+
+    return `Insights:\n${rendered}`;
+  }
+
+  private createPlannerSummary(summary: string): string {
+    const actions = summary
+      .split(/(?<=[.!?])/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .slice(0, 5)
+      .map((item, index) => `${index + 1}. ${item.replace(/^[0-9]+\.\s*/, '')}`)
+      .join('\n');
+
+    return `Action Plan:\n${actions}`;
+  }
+
+  private createCreativeSummary(summary: string): string {
+    const sentences = summary.split(/(?<=[.!?])/).filter(Boolean);
+    if (!sentences.length) {
+      return 'Imagine a future update filled with possibilities.';
+    }
+
+    const intro = sentences[0];
+    const outro = sentences.slice(1, 3).join(' ');
+
+    return `Narrative:\n${intro} ${outro} This scenario paints a vivid snapshot of the topic at hand.`;
+  }
+}

--- a/src/libs/agent-workflow/memory.ts
+++ b/src/libs/agent-workflow/memory.ts
@@ -1,0 +1,22 @@
+import { MemoryMessage } from './types';
+
+export class ConversationMemory {
+  private readonly messages: MemoryMessage[] = [];
+
+  constructor(private readonly maxMessages = 12) {}
+
+  append(message: MemoryMessage) {
+    this.messages.push(message);
+    if (this.messages.length > this.maxMessages) {
+      this.messages.splice(0, this.messages.length - this.maxMessages);
+    }
+  }
+
+  snapshot(): string[] {
+    return this.messages.map((message) => `${message.role.toUpperCase()}: ${message.content}`);
+  }
+
+  clear() {
+    this.messages.length = 0;
+  }
+}

--- a/src/libs/agent-workflow/tools.ts
+++ b/src/libs/agent-workflow/tools.ts
@@ -1,0 +1,104 @@
+import { Tool, ToolExecution } from './types';
+
+export interface StaticSearchDataset {
+  topic: string;
+  headline: string;
+  details: string;
+  url?: string;
+  timestamp?: string;
+}
+
+export class StaticSearchTool implements Tool {
+  public readonly name: string;
+  public readonly description: string;
+  private readonly dataset: StaticSearchDataset[];
+
+  constructor(options: { name?: string; description?: string; dataset: StaticSearchDataset[] }) {
+    this.name = options.name ?? 'static.search';
+    this.description = options.description ?? 'Returns curated news style snippets for well known technology leaders.';
+    this.dataset = options.dataset;
+  }
+
+  async invoke(input: Record<string, unknown>): Promise<ToolExecution> {
+    const query = String(input.query ?? '').toLowerCase();
+    if (!query) {
+      return { output: 'No query provided.', data: { matches: [] } };
+    }
+
+    const matches = this.dataset
+      .filter((item) => item.topic.toLowerCase().includes(query) || query.includes(item.topic.toLowerCase()))
+      .slice(0, 5);
+
+    if (!matches.length) {
+      return { output: `No curated matches for "${query}".`, data: { matches: [] } };
+    }
+
+    const output = matches
+      .map((match, index) => {
+        const url = match.url ? ` (source: ${match.url})` : '';
+        const timestamp = match.timestamp ? ` [${match.timestamp}]` : '';
+        return `${index + 1}. ${match.headline}${timestamp}\n${match.details}${url}`;
+      })
+      .join('\n\n');
+
+    return {
+      output,
+      data: {
+        matches
+      }
+    };
+  }
+}
+
+export interface VirtualFileRecord {
+  path: string;
+  content: string;
+  updatedAt: number;
+}
+
+export class VirtualFileTool implements Tool {
+  public readonly name: string;
+  public readonly description: string;
+  private readonly files = new Map<string, VirtualFileRecord>();
+
+  constructor(options: { name?: string; description?: string } = {}) {
+    this.name = options.name ?? 'virtual.files';
+    this.description = options.description ?? 'Stores artifacts in an in-memory virtual file system.';
+  }
+
+  async invoke(input: Record<string, unknown>): Promise<ToolExecution> {
+    const path = String(input.path ?? '').trim();
+    const content = String(input.content ?? '');
+
+    if (!path) {
+      return { output: 'A "path" value is required to store a file.' };
+    }
+
+    const record: VirtualFileRecord = {
+      path,
+      content,
+      updatedAt: Date.now()
+    };
+
+    this.files.set(path, record);
+
+    return {
+      output: `Saved ${content.length} characters to ${path}.`,
+      data: {
+        file: record
+      }
+    };
+  }
+
+  read(path: string): VirtualFileRecord | undefined {
+    return this.files.get(path);
+  }
+
+  list(): VirtualFileRecord[] {
+    return Array.from(this.files.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  clear() {
+    this.files.clear();
+  }
+}

--- a/src/libs/agent-workflow/types.ts
+++ b/src/libs/agent-workflow/types.ts
@@ -1,0 +1,120 @@
+export interface LLMRequest {
+  prompt: string;
+  context?: string[];
+}
+
+export interface LLMResponse {
+  content: string;
+  tokensUsed: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LLM {
+  readonly id: string;
+  readonly name: string;
+  readonly supportsStreaming?: boolean;
+  generate(request: LLMRequest): Promise<LLMResponse>;
+}
+
+export interface MemoryMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+export interface ToolExecution {
+  output: string;
+  data?: Record<string, unknown>;
+}
+
+export interface Tool {
+  readonly name: string;
+  readonly description: string;
+  invoke(input: Record<string, unknown>): Promise<ToolExecution>;
+}
+
+export interface ToolInvocationPlan {
+  tool: Tool;
+  input: Record<string, unknown>;
+  label?: string;
+}
+
+export interface AgentRunContext {
+  prompt: string;
+  toolResults: ToolExecutionDetail[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ToolExecutionDetail extends ToolExecution {
+  tool: Tool;
+  label: string;
+}
+
+export interface AgentStepResult {
+  response: LLMResponse;
+  prompt: string;
+  toolResults: ToolExecutionDetail[];
+}
+
+export interface WorkflowInput {
+  [key: string]: unknown;
+}
+
+export interface WorkflowStateEntry {
+  id: string;
+  title: string;
+  agent: string;
+  output: AgentStepResult;
+}
+
+export interface WorkflowState {
+  [stepId: string]: WorkflowStateEntry;
+}
+
+export interface WorkflowPrepareArgs {
+  input: WorkflowInput;
+  state: WorkflowState;
+}
+
+export interface WorkflowStepPlan {
+  id: string;
+  title: string;
+  description: string;
+  agent: AgentLike;
+  dependsOn?: string[];
+  prepare(args: WorkflowPrepareArgs): WorkflowPreparedStep;
+}
+
+export interface WorkflowPreparedStep {
+  prompt: string;
+  toolInvocations?: ToolInvocationPlan[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface WorkflowEventBase {
+  stepId: string;
+  timestamp: number;
+}
+
+export type WorkflowEvent =
+  | (WorkflowEventBase & { type: 'step:start'; title: string; agent: string })
+  | (WorkflowEventBase & { type: 'tool:start'; tool: string; label: string })
+  | (WorkflowEventBase & { type: 'tool:end'; tool: string; label: string; output: string })
+  | (WorkflowEventBase & { type: 'llm:complete'; agent: string; tokensUsed: number })
+  | (WorkflowEventBase & { type: 'step:end'; title: string; agent: string });
+
+export type WorkflowObserver = (event: WorkflowEvent) => void;
+
+export interface WorkflowRunResult {
+  input: WorkflowInput;
+  state: WorkflowState;
+  events: WorkflowEvent[];
+  completedAt: number;
+}
+
+export interface AgentLike {
+  name: string;
+  description?: string;
+  runStep(context: AgentRunContext): Promise<AgentStepResult>;
+  reset?: () => void;
+}

--- a/src/libs/agent-workflow/workflow.ts
+++ b/src/libs/agent-workflow/workflow.ts
@@ -1,0 +1,163 @@
+import {
+  AgentLike,
+  AgentRunContext,
+  AgentStepResult,
+  ToolExecutionDetail,
+  ToolInvocationPlan,
+  WorkflowEvent,
+  WorkflowObserver,
+  WorkflowPreparedStep,
+  WorkflowRunResult,
+  WorkflowState,
+  WorkflowStateEntry,
+  WorkflowStepPlan
+} from './types';
+
+function now() {
+  return Date.now();
+}
+
+function ensureUniqueStepIds(steps: WorkflowStepPlan[]) {
+  const ids = new Set<string>();
+  steps.forEach((step) => {
+    if (ids.has(step.id)) {
+      throw new Error(`Duplicate workflow step id detected: ${step.id}`);
+    }
+    ids.add(step.id);
+  });
+}
+
+function dependenciesSatisfied(step: WorkflowStepPlan, state: WorkflowState) {
+  return (step.dependsOn ?? []).every((dependency) => Boolean(state[dependency]));
+}
+
+async function executeToolInvocation(plan: ToolInvocationPlan): Promise<ToolExecutionDetail> {
+  const result = await plan.tool.invoke(plan.input);
+  return {
+    ...result,
+    tool: plan.tool,
+    label: plan.label ?? plan.tool.name
+  };
+}
+
+async function executeAgentStep(agent: AgentLike, context: AgentRunContext): Promise<AgentStepResult> {
+  return agent.runStep(context);
+}
+
+export interface WorkflowOptions {
+  id: string;
+  title: string;
+  description?: string;
+  steps: WorkflowStepPlan[];
+}
+
+export class WorkflowEngine {
+  public readonly id: string;
+  public readonly title: string;
+  public readonly description?: string;
+  private readonly steps: WorkflowStepPlan[];
+
+  constructor(options: WorkflowOptions) {
+    this.id = options.id;
+    this.title = options.title;
+    this.description = options.description;
+    this.steps = options.steps;
+    ensureUniqueStepIds(this.steps);
+  }
+
+  resetAgents() {
+    this.steps.forEach((step) => {
+      step.agent.reset?.();
+    });
+  }
+
+  async run(input: Record<string, unknown>, observer?: WorkflowObserver): Promise<WorkflowRunResult> {
+    const events: WorkflowEvent[] = [];
+    const state: WorkflowState = {};
+    const queue = [...this.steps];
+
+    const pushEvent = (event: WorkflowEvent) => {
+      events.push(event);
+      observer?.(event);
+    };
+
+    while (queue.length) {
+      const step = queue.shift()!;
+      if (!dependenciesSatisfied(step, state)) {
+        queue.push(step);
+        continue;
+      }
+
+      const prepared: WorkflowPreparedStep = step.prepare({ input, state });
+
+      pushEvent({
+        type: 'step:start',
+        stepId: step.id,
+        title: step.title,
+        agent: step.agent.name,
+        timestamp: now()
+      });
+
+      const toolResults: ToolExecutionDetail[] = [];
+      for (const plan of prepared.toolInvocations ?? []) {
+        pushEvent({
+          type: 'tool:start',
+          stepId: step.id,
+          tool: plan.tool.name,
+          label: plan.label ?? plan.tool.name,
+          timestamp: now()
+        });
+        const result = await executeToolInvocation(plan);
+        toolResults.push(result);
+        pushEvent({
+          type: 'tool:end',
+          stepId: step.id,
+          tool: plan.tool.name,
+          label: result.label,
+          output: result.output,
+          timestamp: now()
+        });
+      }
+
+      const agentContext: AgentRunContext = {
+        prompt: prepared.prompt,
+        toolResults,
+        metadata: prepared.metadata
+      };
+
+      const output = await executeAgentStep(step.agent, agentContext);
+
+      pushEvent({
+        type: 'llm:complete',
+        stepId: step.id,
+        agent: step.agent.name,
+        tokensUsed: output.response.tokensUsed,
+        timestamp: now()
+      });
+
+      const entry: WorkflowStateEntry = {
+        id: step.id,
+        title: step.title,
+        agent: step.agent.name,
+        output
+      };
+
+      state[step.id] = entry;
+
+      pushEvent({
+        type: 'step:end',
+        stepId: step.id,
+        title: step.title,
+        agent: step.agent.name,
+        timestamp: now()
+      });
+    }
+
+    return {
+      input,
+      state,
+      events,
+      completedAt: now()
+    };
+  }
+}

--- a/src/pages/AgentWorkbench/index.module.scss
+++ b/src/pages/AgentWorkbench/index.module.scss
@@ -1,0 +1,208 @@
+@import 'src/styles/mixins';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px;
+  max-width: 960px;
+  margin: 0 auto;
+  color: #fff;
+}
+
+.hero {
+  background: rgba(12, 15, 22, 0.76);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+
+  h1 {
+    font-size: 28px;
+    margin: 0 0 12px 0;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.72);
+  }
+}
+
+.form {
+  background: rgba(12, 15, 22, 0.76);
+  border-radius: 20px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.7);
+
+    span {
+      font-size: 12px;
+      text-transform: none;
+      letter-spacing: normal;
+      color: rgba(255, 255, 255, 0.54);
+    }
+
+    input,
+    textarea {
+      background: rgba(24, 29, 36, 0.9);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      padding: 12px;
+      color: #fff;
+      font-size: 16px;
+      resize: vertical;
+
+      &:focus {
+        outline: none;
+        border-color: #8c7ae6;
+        box-shadow: 0 0 0 2px rgba(140, 122, 230, 0.25);
+      }
+    }
+  }
+
+  button {
+    align-self: flex-start;
+    background: linear-gradient(135deg, #8c7ae6, #00c6ff);
+    border: none;
+    border-radius: 12px;
+    color: #0d1117;
+    font-weight: 600;
+    padding: 12px 24px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      box-shadow: none;
+      transform: none;
+    }
+
+    &:not(:disabled):hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 18px rgba(140, 122, 230, 0.35);
+    }
+  }
+}
+
+.section {
+  background: rgba(12, 15, 22, 0.6);
+  border-radius: 20px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.eventLog {
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.eventItem {
+  background: rgba(20, 25, 33, 0.8);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.eventMeta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 6px;
+}
+
+.eventTitle {
+  font-size: 14px;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.card {
+  background: rgba(16, 20, 27, 0.9);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  h3 {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.65);
+    white-space: pre-wrap;
+  }
+}
+
+.files {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.file {
+  background: rgba(20, 25, 33, 0.8);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.fileTitle {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+}
+
+.fileContent {
+  margin: 0;
+  background: rgba(12, 15, 22, 0.8);
+  padding: 12px;
+  border-radius: 12px;
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  color: #b5bde6;
+  max-height: 220px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+@include mobile {
+  .container {
+    padding: 16px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/AgentWorkbench/index.tsx
+++ b/src/pages/AgentWorkbench/index.tsx
@@ -1,0 +1,177 @@
+import classNames from 'classnames';
+import { useMemo, useState } from 'react';
+import { WorkflowEvent, WorkflowRunResult } from 'libs/agent-workflow';
+import { createNewsResearchWorkspace, extractStepMarkdown } from 'libs/agent-workflow/examples';
+import styles from './index.module.scss';
+
+interface EventLogItem {
+  id: string;
+  label: string;
+  detail: string;
+  meta: string;
+}
+
+function renderEvent(event: WorkflowEvent): EventLogItem {
+  const time = new Date(event.timestamp).toLocaleTimeString();
+  switch (event.type) {
+    case 'step:start':
+      return { id: `${event.stepId}-start-${event.timestamp}`, label: `Step • ${event.title}`, detail: 'Started', meta: time };
+    case 'tool:start':
+      return {
+        id: `${event.stepId}-tool-${event.timestamp}`,
+        label: `Tool • ${event.label}`,
+        detail: `Running via ${event.tool}`,
+        meta: time
+      };
+    case 'tool:end':
+      return {
+        id: `${event.stepId}-tool-end-${event.timestamp}`,
+        label: `Tool • ${event.label}`,
+        detail: event.output,
+        meta: time
+      };
+    case 'llm:complete':
+      return {
+        id: `${event.stepId}-llm-${event.timestamp}`,
+        label: `Agent • ${event.agent}`,
+        detail: `Generated response (tokens: ${event.tokensUsed})`,
+        meta: time
+      };
+    case 'step:end':
+    default:
+      return { id: `${event.stepId}-end-${event.timestamp}`, label: `Step • ${event.title}`, detail: 'Completed', meta: time };
+  }
+}
+
+const DEFAULT_PROMPT = 'Search for the latest news about Musk, summarize and save to the desktop as Musk.md';
+
+const DEFAULT_TOPIC_HINT = 'E.g. "Elon Musk", "Tesla", "Neuralink"';
+
+const DEFAULT_FILE_NAME = 'Musk.md';
+
+export default function AgentWorkbench() {
+  const workspace = useMemo(() => createNewsResearchWorkspace(), []);
+  const [topic, setTopic] = useState('Elon Musk');
+  const [fileName, setFileName] = useState(DEFAULT_FILE_NAME);
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
+  const [events, setEvents] = useState<EventLogItem[]>([]);
+  const [result, setResult] = useState<WorkflowRunResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+
+  const runWorkflow = async () => {
+    setIsRunning(true);
+    setEvents([]);
+    setResult(null);
+    workspace.workflow.resetAgents();
+    workspace.fileTool.clear();
+
+    const nextEvents: EventLogItem[] = [];
+    try {
+      const execution = await workspace.workflow.run(
+        {
+          topic: topic.trim() || 'Elon Musk',
+          fileName: fileName.trim() || DEFAULT_FILE_NAME,
+          instructions: prompt.trim()
+        },
+        (event) => {
+          const rendered = renderEvent(event);
+          nextEvents.push(rendered);
+          setEvents([...nextEvents]);
+        }
+      );
+      setResult(execution);
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const files = workspace.fileTool.list();
+
+  return (
+    <div className={classNames(styles.container)}>
+      <section className={styles.hero}>
+        <div>
+          <h1>Agent Workbench</h1>
+          <p>
+            Explore a simplified agentic workflow inspired by the Eko framework. Define a topic, synthesize the findings, and
+            archive the deliverable in a virtual file system.
+          </p>
+        </div>
+        <div className={styles.grid}>
+          {workspace.agents.map((agent) => (
+            <div key={agent.name} className={styles.card}>
+              <h3>{agent.name}</h3>
+              <p>{agent.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.form}>
+        <label>
+          Topic
+          <span>{DEFAULT_TOPIC_HINT}</span>
+          <input value={topic} onChange={(event) => setTopic(event.target.value)} placeholder="Topic" />
+        </label>
+        <label>
+          Workflow Instructions
+          <span>Explain the goal for the workflow. The planner agent will interpret the guidance.</span>
+          <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} rows={3} />
+        </label>
+        <label>
+          Output File Name
+          <span>The archivist will save the generated summary to this virtual path.</span>
+          <input value={fileName} onChange={(event) => setFileName(event.target.value)} placeholder="insights.md" />
+        </label>
+        <button onClick={runWorkflow} disabled={isRunning}>
+          {isRunning ? 'Running workflow…' : 'Run workflow'}
+        </button>
+      </section>
+
+      <section className={styles.section}>
+        <h2>Execution timeline</h2>
+        <div className={styles.eventLog}>
+          {events.map((event) => (
+            <div key={event.id} className={styles.eventItem}>
+              <div className={styles.eventMeta}>
+                <span>{event.label}</span>
+                <span>{event.meta}</span>
+              </div>
+              <div className={styles.eventTitle}>{event.detail}</div>
+            </div>
+          ))}
+          {!events.length && <p>No execution events yet. Run the workflow to see a detailed timeline.</p>}
+        </div>
+      </section>
+
+      {result && (
+        <section className={styles.section}>
+          <h2>Workflow outputs</h2>
+          <div className={styles.grid}>
+            {Object.values(result.state).map((entry) => (
+              <div key={entry.id} className={styles.card}>
+                <h3>{entry.title}</h3>
+                <p>{extractStepMarkdown(result.state, entry.id)}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className={styles.section}>
+        <h2>Virtual files</h2>
+        <div className={styles.files}>
+          {files.map((file) => (
+            <div key={file.path} className={styles.file}>
+              <h4 className={styles.fileTitle}>
+                {file.path} <span>• {new Date(file.updatedAt).toLocaleTimeString()}</span>
+              </h4>
+              <pre className={styles.fileContent}>{file.content}</pre>
+            </div>
+          ))}
+          {!files.length && <p>No files archived yet.</p>}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,7 @@ import GpuStaking from 'pages/GpuStaking';
 import UniversalSwap from 'pages/UniversalSwap/index';
 import GithubLogin from 'pages/GithubLogin';
 import ControlCenter from 'pages/ControlCenter';
+import AgentWorkbench from 'pages/AgentWorkbench';
 
 export default () => (
   <Suspense
@@ -32,6 +33,7 @@ export default () => (
       <Route path="/gpu-credit" element={<GpuCredit />} />
       <Route path="/github-login" element={<GithubLogin />} />
       <Route path="/control-center" element={<ControlCenter />} />
+      <Route path="/agent-workbench" element={<AgentWorkbench />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   </Suspense>

--- a/src/tests/agent-workflow.spec.ts
+++ b/src/tests/agent-workflow.spec.ts
@@ -1,0 +1,30 @@
+import { createNewsResearchWorkspace } from '../libs/agent-workflow/examples';
+import { WorkflowEvent } from '../libs/agent-workflow';
+
+describe('agent workflow engine', () => {
+  it('runs the news research workflow and archives a file', async () => {
+    const workspace = createNewsResearchWorkspace();
+    const received: WorkflowEvent[] = [];
+
+    const result = await workspace.workflow.run(
+      {
+        topic: 'Elon Musk',
+        fileName: 'musk.md',
+        instructions: 'Focus on recent announcements and actionable takeaways.'
+      },
+      (event) => received.push(event)
+    );
+
+    expect(Object.keys(result.state)).toEqual(['research', 'synthesize', 'archive']);
+    expect(received.filter((event) => event.type === 'step:end').map((event) => event.stepId)).toEqual([
+      'research',
+      'synthesize',
+      'archive'
+    ]);
+
+    const file = workspace.fileTool.read('musk.md');
+    expect(file).toBeDefined();
+    expect(file?.content).toContain('# Elon Musk Update');
+    expect(file?.content.toLowerCase()).toContain('action plan');
+  });
+});


### PR DESCRIPTION
## Summary
- create a reusable agent-workflow library with heuristic LLM, tool abstractions, and workflow orchestration helpers inspired by Eko
- add an Agent Workbench page that lets users run the sample news research workflow and inspect events, outputs, and saved files
- cover the workflow engine with a focused Jest test to ensure the virtual archive is generated correctly

## Testing
- yarn test agent-workflow --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68f413baa8e883289fa865b57c3d8b0d